### PR TITLE
Add issues to project board

### DIFF
--- a/.github/workflows/my-workflow.yml
+++ b/.github/workflows/my-workflow.yml
@@ -8,13 +8,18 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@0.8.0
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
+    - uses: actions/github-script@0.8.0
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
             github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: "🎉 You've created this issue comment using GitHub Script!!!"
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: "🎉 You've created this issue comment using GitHub Script!!!"
             })
+            github.projects.createCard({
+            column_id: 10065718,
+            content_id: context.payload.issue.id,
+            content_type: "Issue"
+            });


### PR DESCRIPTION
A new step is added to the workflow, which automatically moves the newly created issue into a column in our project dashboard. The column id is available at [the dashboard view](https://github.com/niuniuanran/write-github-script/projects/1) through getting the column link.